### PR TITLE
Update AnkerGames.lua to v1.3.0

### DIFF
--- a/Scripts/AnkerGames.lua
+++ b/Scripts/AnkerGames.lua
@@ -1,333 +1,286 @@
-local VERSION = "1.2.2"
+-- Project GLD Provider Script: AnkerGames
+local VERSION = "1.3.0"
 client.auto_script_update("https://raw.githubusercontent.com/Y0URD34TH/Project-GLD/refs/heads/main/Scripts/AnkerGames.lua", VERSION)
 
--- Track multiple pending downloads
-local pendingResolvers = {} -- Table to track browser instances by URL
+local searchprovider = "ankergames.net"
+local BASE_URL = "https://ankergames.net"
+local version = client.GetVersionDouble()
 
-local function scrapAnkerGames(gameName, name_script)
-    Notifications.push_warning("Anker Script", "Downloads takes 10 seconds to add and more 10 to start!")
-    local searchUrl = "https://ankergames.net/search/" .. gameName:gsub(" ", "%%20")
-    local headers = {
-        ["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
-    }
-    local resp = http.get(searchUrl, headers)
-    if not resp then
-        return {}
+local session_headers = {
+    ["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+    ["Accept"] = "application/json, text/html",
+    ["X-Requested-With"] = "XMLHttpRequest"
+}
+
+local pendingResolvers = {}
+local imagelink = ""
+local gamename = ""
+local expectedurl = ""
+local pathcheck = ""
+local defaultdir = "C:/Games"
+local pass = ""
+
+-- ============================================================================
+-- PHASE 1: SEARCH LOGIC
+-- ============================================================================
+local function updateSession()
+    local response = http.get(BASE_URL .. "/csrf-token", session_headers)
+    if not response or response == "" then return false end
+    
+    local success, parsedData = pcall(JsonWrapper.parse, response)
+    if success and parsedData and parsedData.token then
+        session_headers["X-CSRF-TOKEN"] = parsedData.token
+        return true
+    end
+    return false
+end
+
+local function sanitize(str)
+    if not str then return "" end
+    return str:lower():gsub("[%s%p]", "")
+end
+
+local function ankersearch()
+    settings.save()
+    updateSession()
+    Notifications.push_success("AnkerGames", "Mr. Ghost's AnkerGames Script loaded.")
+    
+    local getgamename = game.getgamename()
+    if not getgamename or getgamename == "" then 
+        return 
+    end
+    
+    local encodedName = getgamename:gsub(" ", "%%20")
+    local searchUrl = BASE_URL .. "/search/" .. encodedName
+    local htmlContent = http.get(searchUrl, session_headers)
+    
+    if not htmlContent then
+        Notifications.push_error("AnkerGames", "Failed to retrieve search results.")
+        return
     end
     
     local results = {}
+    local cleanedQuery = sanitize(getgamename)
+    local doc = html.parse(htmlContent)
     
-    -- Parse the search results page
-    local doc = html.parse(resp)
-    
-    -- Find all game cards using CSS selector
-    local gameCards = doc:css('a[aria-label*="View details"]')
+    local gameCards = doc:css('article[listing]')
     
     for i = 1, #gameCards do
         local card = gameCards[i]
-        local href = card:attr("href")
-        local ariaLabel = card:attr("aria-label")
+        local listingJson = card:attr("listing")
         
-        if href and ariaLabel then
-        	-- Extract title from aria-label (handles both standard hyphen and em dash)
-        	local title = ariaLabel:match("(.+)%s*—%s*View details") or ariaLabel:match("(.+)%s*%-%s*View details")
+        if listingJson then
+            local json = listingJson:gsub("&quot;", '"'):gsub("\\/", "/")
+            local name = json:match('"title":"([^"]+)"')
+            local slug = json:match('"slug":"([^"]+)"')
+            local version = json:match('"vote_average":"([^"]+)"')
+            local size = json:match('"runtime":"([^"]+)"')
             
-            if title and href:match("^https://ankergames%.net/game/") then
-                -- Fetch the game details page
-                local resp2 = http.get(href, headers)
-                if resp2 then
-                    local gameDoc = html.parse(resp2)
+            if name and slug then
+                if sanitize(name):find(cleanedQuery, 1, true) or cleanedQuery:find(sanitize(name), 1, true) then
+                    local tooltip = "Version: " .. (version or "N/A") .. "\nSize: " .. (size or "N/A")
+                    local displayName = (size and "[".. size .."] " or "") .. name
                     
-                    -- Extract version
-                    local version = nil
-                    local versionNodes = gameDoc:css('[class*="animate-glow"]')
-                    for j = 1, #versionNodes do
-                        local versionText = versionNodes[j]:text()
-                        local v = versionText:match("V%s*([%d%.]+)")
-                        if v then
-                            version = v
-                            break
-                        end
-                    end
-                    
-                    -- Extract size (looking for GB/MB spans)
-                    local size = nil
-                    local sizeSpans = gameDoc:css('span')
-                    for j = 1, #sizeSpans do
-                        local sizeText = sizeSpans[j]:text()
-                        local s = sizeText:match("([%d%.]+%s*[MG]B)")
-                        if s then
-                            size = s
-                            break
-                        end
-                    end
-                    
-                    -- Extract Release Group
-                    local release_group = nil
-                    local rgLinks = gameDoc:css('a[href*="/release-group/"]')
-                    if #rgLinks > 0 then
-                        release_group = rgLinks[1]:text()
-                    end
-                    
-                    -- Build tooltip with extracted information
-                    local tooltip_parts = {}
-                    
-                    if version then
-                        table.insert(tooltip_parts, "Version: V " .. version)
-                    end
-                    
-                    if size then
-                        table.insert(tooltip_parts, "Size: " .. size)
-                    end
-                    
-                    if release_group then
-                        table.insert(tooltip_parts, "Release Group: " .. release_group)
-                    end
-                    
-                    local tooltip = table.concat(tooltip_parts, "\n")
-                    
-                    -- Use size in name if available, otherwise use empty brackets
-                    local displayName = size and "[".. size .."] "..title or title
-                    
-                    local patchresult = {
+                    local searchResult = {
                         name = displayName,
                         links = {},
                         tooltip = tooltip,
-                        ScriptName = name_script
+                        ScriptName = "AnkerGames"
                     }
                     
-                    table.insert(patchresult.links, {
+                    table.insert(searchResult.links, {
                         name = "Download",
-                        link = href,
+                        link = BASE_URL .. "/game/" .. slug,
                         addtodownloadlist = true
                     })
                     
-                    table.insert(results, patchresult)
+                    table.insert(results, searchResult)
                 end
             end
         end
     end
     
-    return results
+    if #results > 0 then
+        communication.receiveSearchResults(results)
+    else
+        Notifications.push("AnkerGames", "No matching games found.")
+    end
 end
 
-local version = client.GetVersionDouble()
-local defaultdir = "C:/Games"
-if version < 6.95 then -- 3.50
+-- ============================================================================
+-- PHASE 2: HYBRID FAST-FETCH RESOLVER
+-- ============================================================================
+local function ondownloadclick(gamejson, downloadurl, scriptname)       
+    if scriptname == "AnkerGames" then
+        local success, jsonResults = pcall(JsonWrapper.parse, gamejson)
+        if success and jsonResults then
+            local coverImageUrl = nil
+            if jsonResults["cover"] and jsonResults["cover"]["url"] then
+                coverImageUrl = jsonResults["cover"]["url"]
+            elseif jsonResults.coverurl then
+                coverImageUrl = jsonResults.coverurl
+            end
+            
+            if coverImageUrl and coverImageUrl:sub(1, 2) == "//" then
+                coverImageUrl = "https:" .. coverImageUrl
+            end
+            if coverImageUrl then
+                coverImageUrl = coverImageUrl:gsub("t_thumb", "t_cover_big")
+            end
+
+            gamename = jsonResults.name or ""
+            imagelink = coverImageUrl or ""
+        end
+    end
+end
+
+local function on_beforedownload(url)
+    if url:match("^https://ankergames%.net/game/") then
+        Notifications.push_warning("AnkerGames", "Download will start in few seconds.")
+        
+        local browserName = "AnkerResolver_" .. tostring(os.time()) .. "_" .. tostring(math.random(1000, 9999))
+        local resolverBrowser = browser.CreateBrowser(browserName, url)
+        browser.set_visible(false, browserName)
+
+        pendingResolvers[resolverBrowser:GetID()] = {
+            originalUrl = url,
+            name = browserName
+        }
+        
+        return "cancel", nil, nil
+    end
+    return nil, nil, nil
+end
+
+local function on_browserloaded(browserID)
+    local resolverBrowser = browser.GetBrowserByID(browserID)
+    if not resolverBrowser then return end
+            
+    if pendingResolvers[browserID] then
+        -- This JS skips the 10s wait and hits the API immediately using the browser's native session state
+        local fastFetchAutomation = [=[
+            if (document.title.includes("Just a moment") || document.title.includes("Cloudflare")) {
+                // Let Cloudflare finish solving before proceeding
+            } else {
+                let match = document.body.innerHTML.match(/generateDownloadUrl\(\s*(\d+)\s*\)/);
+                if (match && match[1]) {
+                    let downloadId = match[1];
+                    let token = document.querySelector('meta[name="csrf-token"]')?.content || '';
+                    
+                    fetch('/generate-download-url/' + downloadId, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': token,
+                            'X-Requested-With': 'XMLHttpRequest'
+                        },
+                        body: JSON.stringify({'g-recaptcha-response': 'development-mode'})
+                    })
+                    .then(res => res.json())
+                    .then(data => {
+                        if (data && data.download_url) {
+                            // Triggers GLD's interceptor immediately
+                            window.location.href = data.download_url;
+                        }
+                    }).catch(err => console.error(err));
+                }
+            }
+        ]=]
+        resolverBrowser:ExecuteJavaScriptOnMainFrame(fastFetchAutomation)
+    end
+end
+
+local function on_browserbeforedownload(browserID, downloadUrl, suggestedName, size)
+    local resolverBrowser = browser.GetBrowserByID(browserID)
+    if not resolverBrowser then return nil end
+            
+    if pendingResolvers[browserID] then
+        local resolverInfo = pendingResolvers[browserID]
+        
+        --expectedurl = downloadUrl
+	expectedurl = resolverInfo.originalUrl
+        Download.SetHistoryUrl(downloadUrl, resolverInfo.originalUrl)
+        
+        resolverBrowser:CloseBrowser()
+        pendingResolvers[browserID] = nil
+        
+        return resolverInfo.originalUrl
+    end
+    return nil
+end
+
+-- ============================================================================
+-- PHASE 3: EXTRACTION LOGIC
+-- ============================================================================
+local function ondownloadcompleted(path, url)
+    if expectedurl == url then
+        local gamenametopath = gamename
+        gamenametopath = gamenametopath:gsub(":", "")
+        defaultdir = menu.get_text("Anker Game Dir") .. "/" .. gamenametopath .. "/"
+        path = path:gsub("\\", "/")
+        pathcheck = path
+	pass = menu.get_text("Pass")
+        local deleteafterextraction = menu.get_bool("Delete After Extraction")
+        zip.extract(path, defaultdir, deleteafterextraction, pass)
+	settings.save()
+    end
+end
+
+local function onextractioncompleted(origin, path)
+    if pathcheck == origin then
+        path = path:gsub("/", "\\")
+        local folders = file.listfolders(path)
+
+        local secondFolder = folders[1]
+        if secondFolder then
+            local fullFolderPath = path .. "\\" .. secondFolder
+            local executables = file.listexecutables(fullFolderPath)
+
+            if executables and #executables >= 1 then
+                local firstExecutable = executables[1]
+                local fullExecutablePath = fullFolderPath .. "\\" .. firstExecutable
+                local gameidl = GameLibrary.GetGameIdFromName(gamename)
+                if gameidl == -1 then
+                    local imagePath = Download.DownloadImage(imagelink)
+                    GameLibrary.addGame(fullExecutablePath, imagePath, gamename, "")
+                    Notifications.push_success("Anker Script", "Game Successfully Installed!")
+                else
+                    GameLibrary.changeGameinfo(gameidl, fullExecutablePath)
+                    Notifications.push_success("Anker Script", "Game Successfully Installed!")
+                end
+            else
+                local executables2 = file.listexecutablesrecursive(fullFolderPath)
+                if executables2 and #executables2 >= 1 then
+                    local firstExecutable = executables2[1]
+                    local gameidl = GameLibrary.GetGameIdFromName(gamename)
+                    if gameidl == -1 then
+                        local imagePath = Download.DownloadImage(imagelink)
+                        GameLibrary.addGame(firstExecutable, imagePath, gamename, "")
+                        Notifications.push_success("Anker Script", "Game Successfully Installed!")
+                    else
+                        GameLibrary.changeGameinfo(gameidl, firstExecutable)
+                        Notifications.push_success("Anker Script", "Game Successfully Installed!")
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- ============================================================================
+-- INITIALIZATION & EVENT REGISTRATION
+-- ============================================================================
+if version < 7.00 then
     Notifications.push_error("Lua Script", "Program is Outdated. Please Update to use this Script")
 else
     Notifications.push_success("Lua Script", "Anker Script Loaded and Working")
     menu.add_input_text("Anker Game Dir")
     menu.set_text("Anker Game Dir", defaultdir)
+    menu.add_input_text("Pass")
+    menu.set_text("Pass", "")
+    menu.add_check_box("Delete After Extraction")
     settings.load()
     
-    local function ankersearch()
-        settings.save()
-        local getgamename = game.getgamename()
-        local scriptname = "AnkerGames"
-
-        local results = scrapAnkerGames(getgamename, scriptname)
-
-        communication.receiveSearchResults(results)
-    end
-    
-    local imagelink = ""
-    local gamename = ""
-    local gamepath = ""
-    local extractpath = ""
-    local expectedurl = ""
-    
-    local function ondownloadclick(gamejson, downloadurl, scriptname)       
-        if scriptname == "AnkerGames" then
-            Notifications.push_warning("Anker Script", "YOUR DOWNLOAD WILL START IN 10 SECONDS")
-            Notifications.push_warning("Anker Script", "DONT PANICK WAIT THE 10 SECONDS!")
-            expectedurl = downloadurl
-        end
-        local jsonResults = JsonWrapper.parse(gamejson)
-        local coverImageUrl = jsonResults["cover"]["url"]
-
-        if coverImageUrl and coverImageUrl:sub(1, 2) == "//" then
-            coverImageUrl = "https:" .. coverImageUrl
-        end
-        if coverImageUrl then
-            coverImageUrl = coverImageUrl:gsub("t_thumb", "t_cover_big")
-        end
-
-        local jsonName = JsonWrapper.parse(gamejson).name
-        gamename = jsonName
-        imagelink = coverImageUrl
-    end
-    
-    -- Download resolver for Anker Games
-    local function on_beforedownload(url)
-        -- Check if this is an Anker Games URL
-        if url:match("^https://ankergames%.net/game/") then
-            Notifications.push_warning("Anker Resolver", "Resolving download link...")
-            
-            -- Generate unique browser name for this download
-            local browserName = "AnkerResolver_" .. tostring(os.time()) .. "_" .. tostring(math.random(1000, 9999))
-            
-            -- Create hidden browser for this download
-            local resolverBrowser = browser.CreateBrowser(browserName, url)
-            browser.set_visible(false, browserName)
-
-            pendingResolvers[resolverBrowser:GetID()] = {
-                originalUrl = url,
-                resolved = false,
-                name = browserName
-            }
-            
-            -- Cancel the original download - we'll resolve it first
-            return "cancel", nil, nil
-        end
-        
-        -- Not an Anker Games URL, let it proceed normally
-        return nil, nil, nil
-    end
-    
-    -- Handle browser load completion for resolvers
-    local function on_browserloaded(browserID)
-        -- Get browser name to check if it's one of our resolvers
-        local resolverBrowser = browser.GetBrowserByID(browserID)
-        if not resolverBrowser then
-            return
-        end
-                
-        -- Check if this is one of our pending resolvers
-        if pendingResolvers[browserID] and not pendingResolvers[browserID].resolved then
-            local resolverInfo = pendingResolvers[browserID]
-            
-            -- Mark as resolved to prevent multiple executions
-            resolverInfo.resolved = true
-            
-            -- Execute the automation script to click download buttons
-local fullAutomation = [=[
-    // Step 1: Find the initial download span by its text and font class
-    const spans = Array.from(document.querySelectorAll('span.font-medium'));
-    const firstSpan = spans.find(s => s.textContent.trim() === 'Download');
-    
-    if (firstSpan) {
-        // Find the actual clickable button that wraps this text
-        const btn = firstSpan.closest('button, a') || firstSpan;
-        btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-    }
-
-    // Step 2: Wait 1 second, then poll for the final download button
-    setTimeout(() => {
-        let attempts = 0;
-        const tryClick = setInterval(() => {
-            // Find the span that uses Alpine.js for the loading state
-            const finalSpan = document.querySelector('span[x-text*="isLoading"]');
-            
-            if (finalSpan) {
-                // Alpine changes the text to 'Download' when the timer finishes
-                if (finalSpan.textContent.trim() === 'Download') {
-                    const dlBtn = finalSpan.closest('button, a') || finalSpan;
-                    dlBtn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-                    clearInterval(tryClick);
-                }
-            } 
-            
-            // Give up after roughly 6 seconds (30 attempts * 200ms)
-            if (attempts++ > 30) {
-                clearInterval(tryClick);
-            }
-        }, 200);
-    }, 1000);
-]=]
-            resolverBrowser:ExecuteJavaScriptOnMainFrame(fullAutomation)
-            resolverBrowser:ExecuteJavaScriptOnFocusedFrame(fullAutomation)
-            Notifications.push_success("Anker Resolver", "Automation script executed!")
-        end
-    end
-    
-    -- Handle browser downloads (when the real download link is triggered)
-    local function on_browserbeforedownload(browserID, downloadUrl, suggestedName, size)
-        local resolverBrowser = browser.GetBrowserByID(browserID)
-        if not resolverBrowser then
-            return nil
-        end
-                
-        -- Check if this download came from one of our resolvers
-        if pendingResolvers[browserID] then
-            local resolverInfo = pendingResolvers[browserID]
-            
-            -- Add the resolved download with the original URL for tracking
-            Download.SetHistoryUrl(downloadUrl, resolverInfo.originalUrl)
-            
-            Notifications.push_success("Anker Resolver", "Download link resolved successfully!")
-            
-            -- Close the resolver browser
-            resolverBrowser:CloseBrowser()
-            
-            -- Clean up resolver tracking
-            pendingResolvers[browserID] = nil
-            
-            -- Return original URL for history tracking
-            return resolverInfo.originalUrl
-        end
-        
-        return nil
-    end
-    
-    local pathcheck = ""
-    local function ondownloadcompleted(path, url)
-        if expectedurl == url then
-            local gamenametopath = gamename
-            gamenametopath = gamenametopath:gsub(":", "")
-            defaultdir = menu.get_text("Anker Game Dir") .. "/" .. gamenametopath .. "/"
-            path = path:gsub("\\", "/")
-            pathcheck = path
-            zip.extract(path, defaultdir, false)
-        end
-        settings.save()
-    end
-    
-    local function onextractioncompleted(origin, path)
-        if pathcheck == origin then
-            path = path:gsub("/", "\\")
-            local folders = file.listfolders(path)
-
-            local secondFolder = folders[1]
-            if secondFolder then
-                local fullFolderPath = path .. "\\" .. secondFolder
-
-                local executables = file.listexecutables(fullFolderPath) -- Returns a vector
-
-                -- Get the first executable (assuming executables[1] exists)
-                if executables and #executables >= 1 then
-                    local firstExecutable = executables[1]
-
-                    local fullExecutablePath = fullFolderPath .. "\\" .. firstExecutable
-                    local gameidl = GameLibrary.GetGameIdFromName(gamename)
-                    if gameidl == -1 then
-                        local imagePath = Download.DownloadImage(imagelink)
-                        GameLibrary.addGame(fullExecutablePath, imagePath, gamename, "")
-                        Notifications.push_success("Anker Script", "Game Successfully Installed!")
-                    else
-                        GameLibrary.changeGameinfo(gameidl, fullExecutablePath)
-                        Notifications.push_success("Anker Script", "Game Successfully Installed!")
-                    end
-                else
-                    local executables2 = file.listexecutablesrecursive(fullFolderPath) -- Returns a vector
-                    if executables2 and #executables2 >= 1 then
-                        local firstExecutable = executables2[1]
-                        local gameidl = GameLibrary.GetGameIdFromName(gamename)
-                        if gameidl == -1 then
-                            local imagePath = Download.DownloadImage(imagelink)
-                            GameLibrary.addGame(firstExecutable, imagePath, gamename, "")
-                            Notifications.push_success("Anker Script", "Game Successfully Installed!")
-                        else
-                            GameLibrary.changeGameinfo(gameidl, firstExecutable)
-                            Notifications.push_success("Anker Script", "Game Successfully Installed!")
-                        end
-                    end
-                end
-            end
-        end
-    end
-    
-    -- Register all callbacks
     client.add_callback("on_scriptselected", ankersearch)
     client.add_callback("on_downloadclick", ondownloadclick)
     client.add_callback("on_beforedownload", on_beforedownload)


### PR DESCRIPTION
I’ve overhauled the AnkerGames provider script to clean up how it handles searches and downloads. I rewrote those core mechanics to make everything much faster.

What's New
- Instant Searches: Instead of making separate, sequential HTTP requests for every single game page to scrape metadata (which was slow and risked rate-limiting), the script now parses the embedded JSON data straight from the search results page.
- Countdown Timer Bypass: Replaced the old browser automation loop (which sat waiting for the 10-second UI timer) with a direct API fetch. The script now grabs the internal downloadId and page CSRF token to request the download URL immediately.
- Archive & Extraction Settings: Added new menu options for zip passwords (Pass) and a toggle to automatically delete the archive after extraction to save disk space.
- Session Stability: Added a pre-search CSRF token refresh routine to minimize dropped or rejected connections.